### PR TITLE
Fix ofp_action_output.max_len en/de-coding; refactor related variables and atoms

### DIFF
--- a/src/ofp_v3_decode.erl
+++ b/src/ofp_v3_decode.erl
@@ -175,7 +175,7 @@ decode_actions(Binary, Actions) ->
             <<PortInt:32, MaxLenInt:16,
               _Pad:48, Rest/bytes>> = Data,
             Port = get_id(port_no, PortInt),
-            MaxLen = get_id(buffer, MaxLenInt),
+            MaxLen = get_id(max_len, MaxLenInt),
             Action = #ofp_action_output{port = Port, max_len = MaxLen};
         group ->
             <<GroupInt:32, Rest/bytes>> = Data,
@@ -482,7 +482,7 @@ decode_body(packet_in, Binary) ->
     MatchLength = size(Binary) - (?PACKET_IN_SIZE - ?MATCH_SIZE)
         - 2 - TotalLen + ?OFP_HEADER_SIZE,
     <<MatchBin:MatchLength/bytes, _Pad:16, Payload/bytes>> = Tail,
-    BufferId = get_id(buffer, BufferIdInt),
+    BufferId = get_id(buffer_id, BufferIdInt),
     Reason = ofp_v3_enum:to_atom(packet_in_reason, ReasonInt),
     Match = decode_match(MatchBin),
     <<Data:TotalLen/bytes>> = Payload,
@@ -687,17 +687,17 @@ decode_body(packet_out, Binary) ->
     DataLength = size(Binary) - ?PACKET_OUT_SIZE + ?OFP_HEADER_SIZE
         - ActionsLength,
     <<ActionsBin:ActionsLength/bytes, Data:DataLength/bytes>> = Binary2,
-    BufferId = get_id(buffer, BufferIdInt),
+    BufferId = get_id(buffer_id, BufferIdInt),
     Port = get_id(port_no, PortInt),
     Actions = decode_actions(ActionsBin),
     #ofp_packet_out{buffer_id = BufferId, in_port = Port,
                     actions = Actions, data = Data};
 decode_body(flow_mod, Binary) ->
     <<Cookie:8/bytes, CookieMask:8/bytes, TableInt:8, CommandInt:8,
-      Idle:16, Hard:16, Priority:16, BufferInt:32, OutPortInt:32,
+      Idle:16, Hard:16, Priority:16, BufferIdInt:32, OutPortInt:32,
       OutGroupInt:32, FlagsBin:2/bytes, _Pad:16, Data/bytes>> = Binary,
     Table = get_id(table, TableInt),
-    Buffer = get_id(buffer, BufferInt),
+    BufferId = get_id(buffer_id, BufferIdInt),
     Command = ofp_v3_enum:to_atom(flow_mod_command, CommandInt),
     OutPort = get_id(port_no, OutPortInt),
     OutGroup = get_id(group, OutGroupInt),
@@ -710,7 +710,7 @@ decode_body(flow_mod, Binary) ->
     Instructions = decode_instructions(InstrBin),
     #ofp_flow_mod{cookie = Cookie, cookie_mask = CookieMask,
                   table_id = Table, command = Command, idle_timeout = Idle,
-                  hard_timeout = Hard, priority = Priority, buffer_id = Buffer,
+                  hard_timeout = Hard, priority = Priority, buffer_id = BufferId,
                   out_port = OutPort, out_group = OutGroup, flags = Flags,
                   match = Match, instructions = Instructions};
 decode_body(group_mod, Binary) ->

--- a/src/ofp_v3_encode.erl
+++ b/src/ofp_v3_encode.erl
@@ -150,7 +150,7 @@ encode_struct(#ofp_action_output{port = Port, max_len = MaxLen}) ->
     Type = ofp_v3_enum:to_int(action_type, output),
     Length = ?ACTION_OUTPUT_SIZE,
     PortInt = get_id(port_no, Port),
-    MaxLenInt = get_id(buffer, MaxLen),
+    MaxLenInt = get_id(max_len, MaxLen),
     <<Type:16, Length:16, PortInt:32, MaxLenInt:16, 0:48>>;
 encode_struct(#ofp_action_group{group_id = Group}) ->
     Type = ofp_v3_enum:to_int(action_type, group),
@@ -338,7 +338,7 @@ encode_body(#ofp_set_config{flags = Flags, miss_send_len = Miss}) ->
     <<FlagsBin:2/bytes, MissInt:16>>;
 encode_body(#ofp_packet_in{buffer_id = BufferId, reason = Reason,
                            table_id = TableId, match = Match, data = Data}) ->
-    BufferIdInt = get_id(buffer, BufferId),
+    BufferIdInt = get_id(buffer_id, BufferId),
     ReasonInt = ofp_v3_enum:to_int(packet_in_reason, Reason),
     MatchBin = encode_struct(Match),
     TotalLen = byte_size(Data),
@@ -367,7 +367,7 @@ encode_body(#ofp_queue_get_config_reply{port = Port, queues = Queues}) ->
     <<PortInt:32, 0:32, QueuesBin/bytes>>;
 encode_body(#ofp_packet_out{buffer_id = BufferId, in_port = Port,
                             actions = Actions, data = Data}) ->
-    BufferIdInt = get_id(buffer, BufferId),
+    BufferIdInt = get_id(buffer_id, BufferId),
     PortInt = get_id(port_no, Port),
     ActionsBin = encode_list(Actions),
     ActionsLength = size(ActionsBin),
@@ -376,12 +376,12 @@ encode_body(#ofp_packet_out{buffer_id = BufferId, in_port = Port,
 encode_body(#ofp_flow_mod{cookie = Cookie, cookie_mask = CookieMask,
                           table_id = Table, command = Command,
                           idle_timeout = Idle, hard_timeout = Hard,
-                          priority = Priority, buffer_id = Buffer,
+                          priority = Priority, buffer_id = BufferId,
                           out_port = OutPort, out_group = OutGroup,
                           flags = Flags, match = Match,
                           instructions = Instructions}) ->
     TableInt = get_id(table, Table),
-    BufferInt = get_id(buffer, Buffer),
+    BufferIdInt = get_id(buffer_id, BufferId),
     CommandInt = ofp_v3_enum:to_int(flow_mod_command, Command),
     OutPortInt = get_id(port_no, OutPort),
     OutGroupInt = get_id(group, OutGroup),
@@ -389,7 +389,7 @@ encode_body(#ofp_flow_mod{cookie = Cookie, cookie_mask = CookieMask,
     MatchBin = encode_struct(Match),
     InstructionsBin = encode_list(Instructions),
     <<Cookie:8/bytes, CookieMask:8/bytes, TableInt:8, CommandInt:8,
-      Idle:16, Hard:16, Priority:16, BufferInt:32, OutPortInt:32,
+      Idle:16, Hard:16, Priority:16, BufferIdInt:32, OutPortInt:32,
       OutGroupInt:32, FlagsBin:2/bytes, 0:16, MatchBin/bytes,
       InstructionsBin/bytes>>;
 encode_body(#ofp_group_mod{command = Command, type = Type,

--- a/src/ofp_v3_enum.erl
+++ b/src/ofp_v3_enum.erl
@@ -176,6 +176,8 @@
                      {set_field, 25},
                      {experimenter, 16#ffff}]}).
 
+-enum({max_len, [{no_buffer, 16#ffff}]}).
+
 %%------------------------------------------------------------------------------
 %% Controller-to-Switch Messages
 %%------------------------------------------------------------------------------
@@ -209,7 +211,7 @@
 %% Modify State Messages -------------------------------------------------------
 
 %% Note: Not in the specification
--enum({buffer, [{no_buffer, 16#ffffffff}]}).
+-enum({buffer_id, [{no_buffer, 16#ffffffff}]}).
 
 -enum({flow_mod_command, [add,
                           modify,

--- a/src/ofp_v4_decode.erl
+++ b/src/ofp_v4_decode.erl
@@ -231,7 +231,7 @@ decode_actions(Binary, Actions) ->
             <<PortInt:32, MaxLenInt:16,
               _Pad:48, Rest/bytes>> = Data,
             Port = get_id(port_no, PortInt),
-            MaxLen = get_id(buffer, MaxLenInt),
+            MaxLen = get_id(max_len, MaxLenInt),
             Action = #ofp_action_output{port = Port, max_len = MaxLen};
         group ->
             <<GroupInt:32, Rest/bytes>> = Data,
@@ -893,7 +893,7 @@ decode_body(packet_in, Binary) ->
     MatchLength = size(Binary) - (?PACKET_IN_SIZE - ?MATCH_SIZE)
         - 2 - TotalLen + ?OFP_HEADER_SIZE,
     <<MatchBin:MatchLength/bytes, _Pad:16, Payload/bytes>> = Tail,
-    BufferId = get_id(buffer, BufferIdInt),
+    BufferId = get_id(buffer_id, BufferIdInt),
     Reason = ofp_v4_enum:to_atom(packet_in_reason, ReasonInt),
     Match = decode_match(MatchBin),
     <<Data:TotalLen/bytes>> = Payload,
@@ -925,17 +925,17 @@ decode_body(packet_out, Binary) ->
     DataLength = size(Binary) - ?PACKET_OUT_SIZE + ?OFP_HEADER_SIZE
         - ActionsLength,
     <<ActionsBin:ActionsLength/bytes, Data:DataLength/bytes>> = Binary2,
-    BufferId = get_id(buffer, BufferIdInt),
+    BufferId = get_id(buffer_id, BufferIdInt),
     Port = get_id(port_no, PortInt),
     Actions = decode_actions(ActionsBin),
     #ofp_packet_out{buffer_id = BufferId, in_port = Port,
                     actions = Actions, data = Data};
 decode_body(flow_mod, Binary) ->
     <<Cookie:8/bytes, CookieMask:8/bytes, TableInt:8, CommandInt:8,
-      Idle:16, Hard:16, Priority:16, BufferInt:32, OutPortInt:32,
+      Idle:16, Hard:16, Priority:16, BufferIdInt:32, OutPortInt:32,
       OutGroupInt:32, FlagsBin:2/bytes, _Pad:16, Data/bytes>> = Binary,
     Table = get_id(table, TableInt),
-    Buffer = get_id(buffer, BufferInt),
+    BufferId = get_id(buffer_id, BufferIdInt),
     Command = ofp_v4_enum:to_atom(flow_mod_command, CommandInt),
     OutPort = get_id(port_no, OutPortInt),
     OutGroup = get_id(group, OutGroupInt),
@@ -948,7 +948,7 @@ decode_body(flow_mod, Binary) ->
     Instructions = decode_instructions(InstrBin),
     #ofp_flow_mod{cookie = Cookie, cookie_mask = CookieMask,
                   table_id = Table, command = Command, idle_timeout = Idle,
-                  hard_timeout = Hard, priority = Priority, buffer_id = Buffer,
+                  hard_timeout = Hard, priority = Priority, buffer_id = BufferId,
                   out_port = OutPort, out_group = OutGroup, flags = Flags,
                   match = Match, instructions = Instructions};
 decode_body(group_mod, Binary) ->

--- a/src/ofp_v4_encode.erl
+++ b/src/ofp_v4_encode.erl
@@ -136,7 +136,7 @@ encode_struct(#ofp_action_output{port = Port, max_len = MaxLen}) ->
     Type = ofp_v4_enum:to_int(action_type, output),
     Length = ?ACTION_OUTPUT_SIZE,
     PortInt = get_id(port_no, Port),
-    MaxLenInt = get_id(buffer, MaxLen),
+    MaxLenInt = get_id(max_len, MaxLen),
     <<Type:16, Length:16, PortInt:32, MaxLenInt:16, 0:48>>;
 encode_struct(#ofp_action_group{group_id = Group}) ->
     Type = ofp_v4_enum:to_int(action_type, group),
@@ -401,7 +401,7 @@ encode_body(#ofp_set_config{flags = Flags, miss_send_len = Miss}) ->
 encode_body(#ofp_packet_in{buffer_id = BufferId, reason = Reason,
                            table_id = TableId, cookie = Cookie,
                            match = Match, data = Data}) ->
-    BufferIdInt = get_id(buffer, BufferId),
+    BufferIdInt = get_id(buffer_id, BufferId),
     ReasonInt = ofp_v4_enum:to_int(packet_in_reason, Reason),
     MatchBin = encode_struct(Match),
     TotalLen = byte_size(Data),
@@ -423,7 +423,7 @@ encode_body(#ofp_port_status{reason = Reason, desc = Port}) ->
     <<ReasonInt:8, 0:56, PortBin/bytes>>;
 encode_body(#ofp_packet_out{buffer_id = BufferId, in_port = Port,
                             actions = Actions, data = Data}) ->
-    BufferIdInt = get_id(buffer, BufferId),
+    BufferIdInt = get_id(buffer_id, BufferId),
     PortInt = get_id(port_no, Port),
     ActionsBin = encode_list(Actions),
     ActionsLength = size(ActionsBin),
@@ -432,12 +432,12 @@ encode_body(#ofp_packet_out{buffer_id = BufferId, in_port = Port,
 encode_body(#ofp_flow_mod{cookie = Cookie, cookie_mask = CookieMask,
                           table_id = Table, command = Command,
                           idle_timeout = Idle, hard_timeout = Hard,
-                          priority = Priority, buffer_id = Buffer,
+                          priority = Priority, buffer_id = BufferId,
                           out_port = OutPort, out_group = OutGroup,
                           flags = Flags, match = Match,
                           instructions = Instructions}) ->
     TableInt = get_id(table, Table),
-    BufferInt = get_id(buffer, Buffer),
+    BufferIdInt = get_id(buffer_id, BufferId),
     CommandInt = ofp_v4_enum:to_int(flow_mod_command, Command),
     OutPortInt = get_id(port_no, OutPort),
     OutGroupInt = get_id(group, OutGroup),
@@ -445,7 +445,7 @@ encode_body(#ofp_flow_mod{cookie = Cookie, cookie_mask = CookieMask,
     MatchBin = encode_struct(Match),
     InstructionsBin = encode_list(Instructions),
     <<Cookie:8/bytes, CookieMask:8/bytes, TableInt:8, CommandInt:8,
-      Idle:16, Hard:16, Priority:16, BufferInt:32, OutPortInt:32,
+      Idle:16, Hard:16, Priority:16, BufferIdInt:32, OutPortInt:32,
       OutGroupInt:32, FlagsBin:2/bytes, 0:16, MatchBin/bytes,
       InstructionsBin/bytes>>;
 encode_body(#ofp_group_mod{command = Command, type = Type,

--- a/src/ofp_v4_enum.erl
+++ b/src/ofp_v4_enum.erl
@@ -202,6 +202,8 @@
                      {pop_pbb, 27},
                      {experimenter, 16#ffff}]}).
 
+-enum({max_len, [{no_buffer, 16#ffff}]}).
+
 %%------------------------------------------------------------------------------
 %% Controller-to-Switch Messages
 %%------------------------------------------------------------------------------
@@ -232,7 +234,7 @@
 
 %% Modify State Messages -------------------------------------------------------
 
--enum({buffer, [{no_buffer, 16#ffffffff}]}).
+-enum({buffer_id, [{no_buffer, 16#ffffffff}]}).
 
 -enum({flow_mod_command, [add,
                           modify,


### PR DESCRIPTION
The ofp_action_output.max_len field was incorrectly encoded/decoded because
it was treated the same as ofp_flow_mod.buffer_id field. Each of these fields
can be set to no_buffer but for different values. For clarity variables' names
and atoms used in encoding/decoding process are refactored.
(Motivated by FlowForwarding/LINC-Switch#124)
