### PR TITLE
Add configuration file for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,6 @@
 language: erlang
+# Can't use R14, as our included rebar is newer.  Let's include a few
+# recent OTP releases.
+otp_release:
+  - R15B03
+  - R16B


### PR DESCRIPTION
Without this file, Travis CI attempts to build this project as if it were a Ruby project.
