### PR TITLE
Change meck dependency to tag 0.8.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 {deps, [{eenum, ".*", {git, "git://github.com/rpt/eenum.git",
                        "ae7f7c3c3e2df8f2cf89ea7c35195139da5d217b"}},
         {meck, ".*", {git, "http://github.com/eproxus/meck.git",
-                      "8433cf2e07862ea8c66e85e2578b7146b4332354"}}]}.
+                      {tag, "0.8.1"}}}]}.
 
 {cover_enabled, true}.
 {cover_print_enabled, true}.


### PR DESCRIPTION
Crucially, this removes a test for parameterised modules, which are no
longer supported in R16.
