### PR TITLE
Add OFPVID_PRESENT and OFPVID_NONE values for matching on VLAN tags

### DIFF
--- a/include/ofp_v4.hrl
+++ b/include/ofp_v4.hrl
@@ -132,6 +132,11 @@
 -define(DESC_STR_LEN, 256).          %% switch description string
 -define(SERIAL_NUM_LEN, 32).         %% serial number string
 
+%% OXM Vlan Id values -----------------------------------------------------------
+
+-define(OFPVID_PRESENT, 16#1000).
+-define(OFPVID_NONE, 16#0000).
+
 %%%-----------------------------------------------------------------------------
 %%% OFP Message Body
 %%%-----------------------------------------------------------------------------


### PR DESCRIPTION
These values are used to indicate special conditions in matching
VLAN tagged frames.
(Motivated by FlowForwarding/LINC-Switch#134).
