### PR TITLE
Add missing values to port_no structure

### DIFF
--- a/src/ofp_v3_enum.erl
+++ b/src/ofp_v3_enum.erl
@@ -69,12 +69,12 @@
 
 -enum({port_no, [{in_port, 16#fffffff8},
                  {table, 16#fffffff9},
-                 normal,
-                 flood,
-                 all,
-                 controller,
-                 local,
-                 any]}).
+                 {normal, 16#fffffffa},
+                 {flood, 16#fffffffb},
+                 {all, 16#fffffffc},
+                 {controller, 16#fffffffd},
+                 {local, 16#fffffffe},
+                 {any, 16#ffffffff}]}).
 
 -enum({port_features, ['10mb_hd',
                        '10mb_fd',

--- a/src/ofp_v4_enum.erl
+++ b/src/ofp_v4_enum.erl
@@ -85,12 +85,12 @@
 
 -enum({port_no, [{in_port, 16#fffffff8},
                  {table, 16#fffffff9},
-                 normal,
-                 flood,
-                 all,
-                 controller,
-                 local,
-                 any]}).
+                 {normal, 16#fffffffa},
+                 {flood, 16#fffffffb},
+                 {all, 16#fffffffc},
+                 {controller, 16#fffffffd},
+                 {local, 16#fffffffe},
+                 {any, 16#ffffffff}]}).
 
 -enum({port_features, ['10mb_hd',
                        '10mb_fd',

--- a/src/ofp_v5_enum.erl
+++ b/src/ofp_v5_enum.erl
@@ -94,12 +94,12 @@
 
 -enum({port_no, [{in_port, 16#fffffff8},
                  {table, 16#fffffff9},
-                 normal,
-                 flood,
-                 all,
-                 controller,
-                 local,
-                 any]}).
+                 {normal, 16#fffffffa},
+                 {flood, 16#fffffffb},
+                 {all, 16#fffffffc},
+                 {controller, 16#fffffffd},
+                 {local, 16#fffffffe},
+                 {any, 16#ffffffff}]}).
 
 -enum({port_desc_properties, [ethernet,
                               optical,


### PR DESCRIPTION
`port_no` is incomplete. Missing values have been added according to the OF specification.
