### PR TITLE
Add macros for OFPVID_PRESENT and OFPVID_NONE values

### DIFF
--- a/include/ofp_v3.hrl
+++ b/include/ofp_v3.hrl
@@ -163,6 +163,11 @@
 -define(DESC_STR_LEN, 256).          %% switch description string
 -define(SERIAL_NUM_LEN, 32).         %% serial number string
 
+%% OXM Vlan Id values -----------------------------------------------------------
+
+-define(OFPVID_PRESENT, 16#1000).
+-define(OFPVID_NONE, 16#0000).
+
 %%% Port Structures ------------------------------------------------------------
 
 -type ofp_port_config() :: port_down


### PR DESCRIPTION
They are used for setting value of match field for a VLAN in packet-in
message.

Motivated by FlowForwarding/LINC-Switch#328.
